### PR TITLE
Fix for 'too many open files' in schema generation

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -216,7 +216,7 @@ const generateSchemaFile = (config, schema, schema_name) => new Promise((resolve
  */
 const generateSchemaFiles = config => new Promise((resolve, reject) => {
   const files = {};
-    if (config.data.openapi.components.schemas) {
+  if (config.data.openapi.components.schemas) {
     _.each(config.data.openapi.components.schemas, (schema, schemaIndex) => {
       console.log(`Generating for ${schema.title}`);
       const schema_name = schema.title
@@ -227,12 +227,12 @@ const generateSchemaFiles = config => new Promise((resolve, reject) => {
       files[schema_name] = {
         schema: schema
       };
-
-      Promise.all(
-        _.map(files, (schema, schema_name) => generateSchemaFile(config, schema, schema_name))
-      ).then(resolve).catch(reject);
-      resolve();
     });
+
+    Promise.all(
+      _.map(files, (schema, schema_name) => generateSchemaFile(config, schema, schema_name))
+    ).then(resolve).catch(reject);
+    resolve();
   } else {
     resolve();
   }


### PR DESCRIPTION
There was an issue where `og` was only generating the first N schema entries. In `generateSchemaFiles`, `N` schema files were being opened `N!`, leading to the error "too many files open" which was silently ignored.

A very weird side effect of this fix is that regenerating the gcsv5 docs revealed several schema components that were missing example fields. The previous version of `og` was somehow inserting useful and consistent UUID's when the field in api.yaml didn't supply it.  I'm chalking it up to weirdness due to the "too many files open" silent error. 